### PR TITLE
Added secret key to devise.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -19,6 +19,7 @@
 #   # available as additional gems.
    require 'devise/orm/mongoid'
 
+   config.secret_key = '0d8d2bd1a830014e0c06227e2054edf48b20c39b2eecf4aaca0bff824a7dace96f10c835e40c56ecf99e05519758441a193590e8cbc9b9f358d805ce31bfbf0d'
 #   # ==> Configuration for any authentication mechanism
 #   # Configure which keys are used when authenticating a user. The default is
 #   # just :email. You can configure it to use [:username, :subdomain], so for


### PR DESCRIPTION
There is a problem in devise 3.0.3 that throws an error when creating accounts (https://github.com/plataformatec/devise/issues/2574). This may be unique to scoped Models, but I'm not sure since we don't have a sign up process for CMS users. 

Anyway, I needed to update the version, which means I now need to add a secret_key to the devise config for devise to work (http://blog.plataformatec.com.br/2013/08/devise-3-1-now-with-more-secure-defaults/). Wanted to check with you on this before I committed any changes as this might affect others using the CMS.
