### PR TITLE
[#56904820] added inherited model level validations to cms

### DIFF
--- a/app/models/clear_cms/content.rb
+++ b/app/models/clear_cms/content.rb
@@ -53,7 +53,6 @@ module ClearCMS
 
     #after_save :update_search_index #OLD FOR INDEXTANK
     before_save :set_publish_at
-    before_validation :run_validations_by_type
     after_save :schedule_cache_clear
     after_save :notify_assignee
 
@@ -64,7 +63,7 @@ module ClearCMS
 
     accepts_nested_attributes_for :content_blocks, :content_notes, :content_logs, :linked_contents, :allow_destroy=>true
 
-    #attr_accessible :_type
+    # attr_accessible :_type
 
     belongs_to :site, class_name: 'ClearCMS::Site', :inverse_of => :contents
     belongs_to :creator, class_name: 'ClearCMS::User', :inverse_of => :created_contents
@@ -78,7 +77,7 @@ module ClearCMS
     belongs_to :original_translation, :class_name => 'ClearCMS::Content', :inverse_of => :translations
 
 
-    #field :type
+    # field :type
     field :title
     field :subtitle
     field :basename
@@ -280,39 +279,6 @@ module ClearCMS
 
 
 private
-
-    def run_validations_by_type
-        case self._type
-        when "Apartment" #belongs to volume
-          validates_presence_of :apartment_number, :volume_id, :address, :hours
-          validates_uniqueness_of :apartment_number
-          validates_numericality_of :apartment_number, only_integer: true
-          validates_length_of :address, :hours, maximum: 215
-        when "Volume" #has many chapters and apartments
-          validates_presence_of :volume_number
-          validates_uniqueness_of :volume_number
-          validates_numericality_of :volume_number, only_integer: true
-        when "Brand" # has many products
-          validates_numericality_of :artist, :hide_from_designer_index, only_integer: true
-          validates_numericality_of :established, only_integer: true, allow_blank: true
-        when "Chapter" #belongs to volume
-          validates_presence_of :chapter_number, :volume_id, :short_description
-          validates_uniqueness_of :chapter_number
-          validates_numericality_of :chapter_number, only_integer: true
-          validates_length_of :short_description, maximum: 215
-          validates_inclusion_of :linked_item_limit, in: 4..20, allow_blank: true
-        when "Event" # belongs to apartment
-          validates_presence_of :start_time, :end_time, :apartment_id
-        when "Product"
-          validates_presence_of :brand_id, :product_state, :available_date
-          validates_numericality_of :brand_id
-          validates_numericality_of :original_price, :external_price, allow_nil: true, allow_blank: true, greater_than_or_equal_to: 0
-          validates_numericality_of :exclusive, :spree_product_id, :brightpearl_product_group_id, :brightpearl_brand_id, allow_blank: true, only_integer: true
-        when "ProductFeature"
-          validates_length_of :short_description, maximum: 215, allow_nil: true, allow_blank: true
-        else
-        end
-    end
 
     def update_search_index
       if self.published?


### PR DESCRIPTION
Used before_validation callback to run inherited model level validations on the CMS. I couldn't think of how to validate without using the callback as I needed to get the attribute "_type" in order to figure out which validations to run. Felt a bit 'dirty' because the inherited models weren't in the CMS and the validations depended on their type, so please let me know if these should live elsewhere. 
