### PR TITLE
Remove parent ids in nested docs

### DIFF
--- a/app/assets/javascripts/clear_cms/models/contentAsset.js
+++ b/app/assets/javascripts/clear_cms/models/contentAsset.js
@@ -1,6 +1,5 @@
 ClearCms.ContentAsset = DS.Model.extend({
   primaryKey: '_id',
-  content_block: DS.belongsTo('content_block', {embedded: 'always'}),
   file: DS.attr('string'),
   path: DS.attr('string'),
   mounted_file: DS.attr(),

--- a/app/assets/javascripts/clear_cms/models/contentBlock.js
+++ b/app/assets/javascripts/clear_cms/models/contentBlock.js
@@ -1,6 +1,5 @@
 ClearCms.ContentBlock = DS.Model.extend({
   primaryKey: '_id',
-  content: DS.belongsTo('content',{embedded: 'always'}),
   body: DS.attr('string'),
   type: DS.attr('string'),
   content_assets: DS.hasMany('content_asset', {embedded: 'always'}),


### PR DESCRIPTION
this takes the parent ids out.   now the problem with .save() is that the adapter wants to PUT to `/:content_id/edit` and not `/:content_id` like convention... it's been hard to figure out why. 
