### PR TITLE
follow cancan pattern for setting guest user if nil, fixes [#92558290]

### DIFF
--- a/app/models/clear_cms/ability.rb
+++ b/app/models/clear_cms/ability.rb
@@ -2,6 +2,8 @@ class ClearCMS::Ability
   include CanCan::Ability
 
   def initialize(user)
+    user ||= ClearCMS::User.new
+
     can :manage, :all
 
     can :manage, :all if user.system_permission == 'administrator'


### PR DESCRIPTION
@niedfelj - just following the pattern suggested in cancan docs to use User.new if current_user ends up being nil. now it won't throw error when trying to go directly to CMS pages if not logged in.

would i also need to add this line to the other ability.rb in app/models/ ? 
