### PR TITLE
[#91889714] lock alumni out of cms read or write

### DIFF
--- a/app/models/clear_cms/ability.rb
+++ b/app/models/clear_cms/ability.rb
@@ -6,7 +6,7 @@ class ClearCMS::Ability
 
     if user.system_permission == 'alumni'
 
-      can :update, ClearCMS::User, :id => user.id
+      can :edit, ClearCMS::User, :id => user.id
 
     else
 

--- a/app/models/clear_cms/ability.rb
+++ b/app/models/clear_cms/ability.rb
@@ -4,19 +4,26 @@ class ClearCMS::Ability
   def initialize(user)
     user ||= ClearCMS::User.new
 
-    can :manage, :all
+    if user.system_permission == 'alumni'
 
-    can :manage, :all if user.system_permission == 'administrator'
+      can :update, ClearCMS::User, :id => user.id
 
-    can :update, ClearCMS::User, :id => user.id
+    else
 
-    can :read, ClearCMS::Content if user.system_permission == 'editor'
+      can :manage, :all
 
-    can :manage, ClearCMS::Asset #if user.system_permission == 'editor' #ability to upload images using async widget
+      can :manage, :all if user.system_permission == 'administrator'
 
-    can :update, ClearCMS::Content, :assignee_id => user.id
+      can :update, ClearCMS::User, :id => user.id
 
-    can :manage, ClearCMS::HistoryTracker if user.system_permission == 'editor'
+      can :read, ClearCMS::Content if user.system_permission == 'editor'
+
+      can :manage, ClearCMS::Asset #if user.system_permission == 'editor' #ability to upload images using async widget
+
+      can :update, ClearCMS::Content, :assignee_id => user.id
+
+      can :manage, ClearCMS::HistoryTracker if user.system_permission == 'editor'
+    end
 
     #can :manage, :all if user[:email]=='josh@coolhunting.com'
     #can :manage, :all if user[:email]=='joel@coolhunting.com'


### PR DESCRIPTION
@placenamehere @niedfelj  Added an if statement to check for for system_permission == alumni, and if they are redirected to edit their own user account. They can only edit their own user info (name, email), excluding roles so they can't change back to non-alumni. This works for locking them out of cms read/write ability. 

Let me know if you have any questions. thanks
