### PR TITLE
refactor categories to use aggregation pipeline instead of map-reduce

### DIFF
--- a/app/models/clear_cms/site.rb
+++ b/app/models/clear_cms/site.rb
@@ -41,6 +41,14 @@ module ClearCMS
         {"$sort" => {_id: 1}}])
     end
 
+    def tags
+      ClearCMS::Content.collection.aggregate([
+        {"$match" => {"site_id" => self.id}},
+        {"$unwind" => "$tags"},
+        {"$group" => {_id: "$tags", :count => {"$sum" => 1}}},
+        {"$sort" => {_id: 1}}])
+    end
+
 private
 
     def remove_permissions

--- a/app/models/clear_cms/site.rb
+++ b/app/models/clear_cms/site.rb
@@ -4,63 +4,44 @@ module ClearCMS
     #include Mongoid::Versioning
     # keep at most 5 versions of a record
     #max_versions 5
-    
+
     after_destroy :remove_permissions
-    
-    
+
+
     has_many :contents, class_name: 'ClearCMS::Content', :inverse_of => :site #, :dependent => :destroy
-    
+
     field :name
     field :domain
-    field :slug 
+    field :slug
     field :keywords
     field :description
     field :language
-    
+
     field :source_id
     field :source_attributes, type: Hash
-    
+
     validates_presence_of :name
-    
+
     validates_presence_of :slug
     validates_uniqueness_of :slug
-    
+
     validates_presence_of :domain
     validates_uniqueness_of :domain
-    
-    
+
+
     def self.content_columns
       fields.collect {|f| f[1]}
     end
-    
-    
-    def categories
-      map = %Q{
-        function() {
-           exclude_categories=/(view_by|[0-9])/i;
-           for (var idx = 0; idx < this.categories.length; idx++) {
-               var key = this.categories[idx];
-               if(!(exclude_categories.test(key))) {
-                emit(key, {count: 1});
-               }
-           }
-        }
-      }
-      
-      reduce = %Q{
-        function(key, values) {
-          var result = { count: 0 };
-          values.forEach(function(value) {
-            result.count += value.count;
-          });
-          return result;
-        }
-      }
 
-      contents.count > 1 ? contents.map_reduce(map,reduce).out(inline:true) : []
+    def categories
+      ClearCMS::Content.collection.aggregate([
+        {"$match" => {"site_id" => self.id}},
+        {"$unwind" => "$categories"},
+        {"$group" => {_id: "$categories", :count => {"$sum" => 1}}},
+        {"$sort" => {_id: 1}}])
     end
 
-private 
+private
 
     def remove_permissions
       ClearCMS::User.where('permissions.site_id'=>self.id).each do |u|
@@ -68,6 +49,6 @@ private
       end
     end
 
-      
+
   end
 end

--- a/app/views/clear_cms/contents/_form.html.erb
+++ b/app/views/clear_cms/contents/_form.html.erb
@@ -54,7 +54,7 @@ var linkedFiltersType = {
         <%= f.input :basename, :hint=>'Must not contain spaces or special chars', :input_html=>{:class=>'protected'} %>
         <%= f.input :author, :collection=>(ClearCMS::User.active + [@clear_cms_content.author]).compact.uniq %>
         <!-- need to overwrite value below because of known formtasic bug flattening the array: https://github.com/justinfrench/formtastic/issues/1144 -->
-        <%= f.input :tags, :input_html=>{:class=>'input-xlarge', :value=> @clear_cms_content.tags.present? ? @clear_cms_content.tags.join(', ').to_json : '' }%>
+        <%= f.input :tags, :input_html=>{:class=>'input-xlarge', :value=> @clear_cms_content.tags.present? ? @clear_cms_content.tags.join(', ').to_json : '', 'autocomplete'=>'off', 'data-provide'=>"typeahead", 'data-source'=>@clear_cms_content.site.tags.collect {|t| t['_id'] }.to_json} %>
         <%= f.input :categories, :input_html=>{:class=>'input-xlarge', :value=> @clear_cms_content.categories.present? ? @clear_cms_content.categories.join(', ').to_json : '', 'autocomplete'=>'off', 'data-provide'=>"typeahead", 'data-source'=>@clear_cms_content.site.categories.collect {|c| c['_id'] }.to_json} %>
         <% ClearCMS::Content.form_fields.each do |field,options| %>
           <%= f.input field, options[:formtastic_options].merge(:wrapper_html=>{'data-types'=>options[:models].to_json}) %>


### PR DESCRIPTION
aggregation framework (runs in compiled C++):

```
 runtime: 28.8640ms
```

versus

map-reduce (must convert every document to JSON):

```
runtime: 336.1640ms
```

also the hash returned of categories and their counts is simpler (less nesting).  it does not look like anything was making use of anything besides the keys.
