### PR TITLE
Fix warnings

### DIFF
--- a/app/models/clear_cms/asset.rb
+++ b/app/models/clear_cms/asset.rb
@@ -3,16 +3,16 @@ class ClearCMS::Asset
 
   #after_initialize :generate_path
 
-  
+
   #before_save :output_contents
-  #before_create :append_site_to_path   
+  #before_create :append_site_to_path
 
   #embedded_in :content_block, class_name: 'ClearCMS::ContentBlock'
 
   mount_uploader :file, ClearCMS::Uploaders::ContentAssetUploader
-  
+
   after_save :enqueue_processing
-  
+
   field :path
   field :caption
   field :order, type: Integer
@@ -36,24 +36,24 @@ class ClearCMS::Asset
 #     end
 #   end
 
-  
-#   def path 
+
+#   def path
 # #     #debugger
 # #     return nil if self[:path].blank?
-# # 
-# #     self.content_block && self.content_block.content && site=self.content_block.content.site      
+# #
+# #     self.content_block && self.content_block.content && site=self.content_block.content.site
 # #     if site
 # #       self[:path].start_with?(site.slug) ? self[:path] : File.join(site.slug,self[:path])
-# #     else        
+# #     else
 # #       self[:path]
 # #     end
 #   end
-  
+
 #   def remote_file_url=(url)
 #     self[:path]=File.dirname(URI.parse(url).path)[1..-1]
 #     super(url)
 #   end
-  
+
   def uploader_json
    json=%Q{  {
         "name": "#{file.file.filename}",
@@ -63,13 +63,13 @@ class ClearCMS::Asset
         "thumbnail_url": "#{file.url}",
         "delete_url": "http:\/\/none",
         "delete_type": "DELETE"
-      } 
+      }
     }
   end
 
   class ImageWorker
-    include Sidekiq::Worker 
-    
+    include Sidekiq::Worker
+
     def perform(id)
       asset = ::ClearCMS::Asset.find(id)
       asset.remote_file_url = asset.original_file_url
@@ -77,31 +77,31 @@ class ClearCMS::Asset
       asset.update_attribute(:processed_at,Time.now)
     end
   end
-  
 
-private 
+
+private
 
 
   def enqueue_processing
     if original_file_url_changed?
-      ImageWorker.perform_async(id.to_s)    
+      ImageWorker.perform_async(id.to_s)
     end
   end
 
 #   def generate_path
 #     self.path=Time.now.strftime('%Y/%m/%d')
 #   end
-  
+
 #   def output_contents
 #     logger.info self.inspect
 #   end
-#   
+#
 #   def append_site_to_path
 #     self.content_block && self.content_block.content && site=self.content_block.content.site
 #     if site
 #       #logger.info "string #{site.slug}, #{path}"
-#       path=File.join(site.slug,(path||'content_assets'))      
+#       path=File.join(site.slug,(path||'content_assets'))
 #     end
 #   end
-  
+
 end

--- a/app/models/clear_cms/content.rb
+++ b/app/models/clear_cms/content.rb
@@ -25,7 +25,7 @@ module ClearCMS
       self.form_fields[field_name] ||= {:models=>[],:formtastic_options=>{}}
 
       formtastic_options=options.delete(:formtastic_options)||{}
-      #options={}
+      options[:overwrite] = true
 
       case self.name
       when 'ClearCMS::Content'

--- a/app/models/clear_cms/content_asset.rb
+++ b/app/models/clear_cms/content_asset.rb
@@ -21,7 +21,7 @@ class ClearCMS::ContentAsset
   field :description
   field :credit
   field :placement
-  field :file
+  field :file, overwrite: true
   field :width
   field :height
 

--- a/lib/clear_cms/configuration.rb
+++ b/lib/clear_cms/configuration.rb
@@ -37,7 +37,6 @@ module ClearCMS
       fog_directory: 'fog-uploads-directory',
       fog_attributes: {},
       asset_host: 'http://assets.example.com',
-      mailer_sender: 'no-reply@captainlucas.com',
       sidekiq_redis_url: 'redis://localhost:6379'
 
     }

--- a/lib/clear_cms/version.rb
+++ b/lib/clear_cms/version.rb
@@ -1,3 +1,3 @@
 module ClearCMS
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Currently loading the environment generates copies number of warnings to the effect of `Overwriting existing field blah_blah in class ClearCMS::Content.` The `:overwrite` option fixes that.

Furthermore, there's a duplicate key in the in the config generating a warning so I fixed that, too.
